### PR TITLE
Revert "Bump gtfs-structures from 0.35.0 to 0.36.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "gtfs-structures"
-version = "0.36.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf52f20cd24589877ba65e8a6285a365e43dcd7801d9ecfd70d0870fa35f9259"
+checksum = "874f29ec17c0e7026652df0c441c589b3299c5e0ebee8e7855176d30bb41b400"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ csv = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.33", features = ["full"] }
 futures = "0.3"
-gtfs-structures = "0.36.0"
+gtfs-structures = "0.35.0"
 tungstenite = "0.20.1"
 postgres = "0.19.7"
 postgis = "0.9.0"


### PR DESCRIPTION
Reverts CatenaryMaps/catenary-backend#29